### PR TITLE
let env determine the path to bash

### DIFF
--- a/lpd.sh
+++ b/lpd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #  This is a test
 


### PR DESCRIPTION
Not all systems have bash installed in /bin (OpenBSD for example). This change finds bash anywhere in the users $PATH envy var.
